### PR TITLE
Updated the Android Gradle Plugin to 4.1.3 and removed JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,9 @@ buildscript {
 
         // Needed for the Android Gradle Plugin to work
         google()
-        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
     }
 }
 
@@ -118,7 +117,7 @@ ext {
 }
 
 android {
-    compileSdkVersion(compileSdk)
+    compileSdkVersion(project.ext.compileSdk)
 
     // Make it clear we're compiling for Java 8
     compileOptions {
@@ -142,17 +141,17 @@ android {
     }
 
     defaultConfig {
-        targetSdkVersion(targetSdk)
-        minSdkVersion(minSdk)
+        targetSdkVersion(project.ext.targetSdk)
+        minSdkVersion(project.ext.minSdk)
         multiDexEnabled true
     }
 
     signingConfigs {
         release {
-            storeFile file(keyStoreToUse)
-            storePassword storePassToUse
-            keyAlias keyAliasToUse
-            keyPassword keyPassToUse
+            storeFile file(project.ext.keyStoreToUse)
+            storePassword project.ext.storePassToUse
+            keyAlias project.ext.keyAliasToUse
+            keyPassword project.ext.keyPassToUse
         }
     }
 


### PR DESCRIPTION
### Description
This pull request updates the version of the Android Gradle Plugin used to 4.1.3, which is currently the latest version.

As mentioned in https://github.com/MovingBlocks/DestSolAndroid/pull/17#discussion_r583947201, it was not possible previously to remove the JCenter repository, as the android gradle plugin depended on a dependency only found in it. This dependency has now been published to Maven Central (see [here](https://youtrack.jetbrains.com/issue/IDEA-261387#focus=Comments-27-4820597.0-0)), so the repository can be removed.
### Testing
In a `DestinationSol` workspace with an android facade including these changes, run the command `gradlew buildDebug --no-build-cache --refresh-dependencies`. The engine and android facade build should run without any compilation or gradle build errors.

If you can provide a signing keystore (the default debug keystore should work) then you can run the release build command `gradlew build --no-build-cache --refresh-dependencies -PsigningKeystore=<path_to_keystore> -PsigningStorePass=<keystore_password> -PsigningKeyAlias=<key_alias> -PsigningKeyPass=<key_password>`, with the relevant values substituted in.

Optionally, you can test that the built android APK runs correctly. You can do this by installing the APK file generated at `android/build/outputs/apk/debug/android-debug.apk` onto a device or emulator and running the installed "Dest. Sol" app.

### Notes
- This relates to MovingBlocks/Terasology#4582.