### PR TITLE
Removed code/asset split and added arm64 natives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ libs/armeabi/
 libs/armeabi-v7a/
 libs/arm64-v8a/
 libs/x86/
+libs/x86_64/
 gen/
 .idea/
 *.ipr

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ## Android Studio and Intellij and Android in general
 libs/armeabi/
 libs/armeabi-v7a/
+libs/arm64-v8a/
 libs/x86/
 gen/
 .idea/

--- a/build.gradle
+++ b/build.gradle
@@ -78,10 +78,12 @@ dependencies {
     implementation "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
     natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi"
     natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi-v7a"
+    natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-arm64-v8a"
     natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-x86"
     implementation "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-armeabi"
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-armeabi-v7a"
+    natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-arm64-v8a"
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-x86"
 }
 
@@ -172,6 +174,7 @@ task copyAndroidNatives() {
 
     configurations.natives.files.each { jar ->
         def outputDir = null
+        if(jar.name.endsWith("natives-arm64-v8a.jar")) outputDir = file("libs/arm64-v8a")
         if(jar.name.endsWith("natives-armeabi-v7a.jar")) outputDir = file("libs/armeabi-v7a")
         if(jar.name.endsWith("natives-armeabi.jar")) outputDir = file("libs/armeabi")
         if(jar.name.endsWith("natives-x86.jar")) outputDir = file("libs/x86")

--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,9 @@ dependencies {
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-armeabi-v7a"
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-arm64-v8a"
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-x86"
+
+    // Android-compatible logging
+    implementation group: 'org.slf4j', name: 'slf4j-android', version: '1.7.25'
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -202,27 +202,38 @@ def deleteDir(File dir) {
     dir.delete()
 }
 
-task copyModules() {
+task modulesJar
+rootProject.destinationSolModules().each { module ->
+    modulesJar.dependsOn ":modules:$module.name" + ":jar"
+}
+
+task exportModules() {
     inputs.dir("$rootDir/engine/src/main/resources/")
-    inputs.dir("$projectDir/assets")
+    for (module in rootProject.destinationSolModules()) {
+        def moduleClassesDir = "${rootProject.projectDir}/modules/${module.name}/build/classes"
+        def assetsDir = "${rootProject.projectDir}/modules/${module.name}/assets"
+        if (file(moduleClassesDir).exists()) {
+            inputs.dir(moduleClassesDir)
+            inputs.dir(assetsDir)
+        }
+    }
+
+    outputs.dir("$projectDir/assets/modules")
+
     dependsOn ":engine:cacheReflections"
+    dependsOn modulesJar
 
     doLast {
         // Clear the modules directory to ensure that it is up-to date
         deleteDir(new File("$projectDir/assets", "modules"))
 
         copy {
-            from "$rootDir"
-            into "$projectDir/assets"
-            include "modules/**"
-            exclude "modules/modules.iml"
-            exclude "modules/*/*.iml"
-            exclude "modules/*/README.md"
-            exclude "modules/*/LICENSE.md"
-            exclude "modules/*/build.gradle"
-            exclude "modules/*/build"
-            exclude "modules/*/src"
-            exclude "modules/subprojects.gradle"
+            into "$projectDir/assets/modules"
+            rootProject.destinationSolModules().each { module ->
+                from("$rootDir/modules/${module.name}/build/libs") {
+                    include "*.jar"
+                }
+            }
         }
 
         copy {
@@ -237,96 +248,66 @@ task copyModules() {
             into "$projectDir/assets/modules/engine"
             include "reflections.cache"
         }
+
+        dexModules()
     }
 }
 
-task modulesCompile
-rootProject.destinationSolModules().each { module ->
-    modulesCompile.dependsOn ":modules:$module.name" + ":compileJava"
-}
+def dexModules() {
+    def path = androidSdkPath()
+    def dexCommand = System.getProperty("os.name").toLowerCase().contains("windows") ? "d8.bat" : "d8"
+    def buildToolsVersions = new File(path, "build-tools").listFiles(new FileFilter() {
+        @Override
+        boolean accept(File file) {
+            return file.isDirectory() && file.name.startsWith("$compileSdk.")
+        }
+    })
 
-task reflectModules() {
+    if (buildToolsVersions.length == 0) {
+        throw new TaskExecutionException(reflectModules, new FileNotFoundException("The Android SDK build tools version $compileSdk could not be found."))
+    }
+    def dex = "${buildToolsVersions[0]}/$dexCommand"
     for (module in rootProject.destinationSolModules()) {
-        def moduleClassesDir = "${rootProject.projectDir}/modules/${module.name}/build/classes"
-        if (file(moduleClassesDir).exists()) {
-            inputs.dir(moduleClassesDir)
+        def moduleClassesDir = "${rootProject.projectDir}/modules/${module.name}/build/classes/"
+        def moduleClassesFiles = fileTree(moduleClassesDir).filter { it.isFile() && it.name.endsWith('.class')}.files
+        def classesRootPath = new File(moduleClassesDir).toPath()
+        def moduleClasses = []
+        for (file in moduleClassesFiles) {
+            moduleClasses.add(classesRootPath.relativize(file.toPath()))
         }
-    }
-
-    dependsOn modulesCompile
-    dependsOn copyModules
-
-    doLast {
-        def path = androidSdkPath()
-        def dexCommand = System.getProperty("os.name").toLowerCase().contains("windows") ? "d8.bat" : "d8"
-        def buildToolsVersions = new File(path, "build-tools").listFiles(new FileFilter() {
-            @Override
-            boolean accept(File file) {
-                return file.isDirectory() && file.name.startsWith("$compileSdk.")
-            }
-        })
-
-        if (buildToolsVersions.length == 0) {
-            throw new TaskExecutionException(reflectModules, new FileNotFoundException("The Android SDK build tools version $compileSdk could not be found."))
+        if (moduleClasses.size() == 0) {
+            // The dexed code jars are only produced for code-bearing modules.
+            continue;
         }
-        def dex = "${buildToolsVersions[0]}/$dexCommand"
-        for (module in rootProject.destinationSolModules()) {
-            def moduleVersion = new JsonSlurper().parseText(new File("$rootDir/modules/${module.name}/module.json").text).version
-            def moduleClassesDir = "${rootProject.projectDir}/modules/${module.name}/build/classes/"
-            def moduleClassesFiles = fileTree(moduleClassesDir).filter { it.isFile() && it.name.endsWith('.class')}.files
-            def classesRootPath = new File(moduleClassesDir).toPath()
-            def moduleClasses = []
-            for (file in moduleClassesFiles) {
-                moduleClasses.add(classesRootPath.relativize(file.toPath()))
+        def moduleDexesDir = "${rootProject.projectDir}/modules/${module.name}/build/dexes/"
+        mkdir(moduleDexesDir)
+        exec {
+            workingDir moduleClassesDir
+            commandLine (["$dex"] + moduleClasses + ['--classpath', "$rootDir/engine/build/classes",
+                                                     '--lib', "$path/platforms/android-$compileSdk/android.jar",
+                                                     '--min-api', "$minSdk",
+                                                     '--output', "$moduleDexesDir"])
+        }
+
+        def moduleDexesFiles = fileTree(moduleDexesDir).filter { it.isFile() && it.name.endsWith('.dex')}.files
+        def jarOutputDir = "$projectDir/assets/modules/${module.name}-${module.version}.jar"
+        FileSystem jarFileSystem
+        try {
+            jarFileSystem = FileSystems.newFileSystem(URI.create("jar:" + new File(jarOutputDir).toURI()), new HashMap<String, Object>())
+            moduleDexesFiles.each {
+                Files.copy(it.toPath(), jarFileSystem.getPath("/${it.name}"))
             }
-            if (moduleClasses.size() == 0) {
-                // The dexed code jars are only produced for code-bearing modules.
-                continue;
-            }
-            def jarOutputDir = "$projectDir/assets/modules/${module.name}-code-${moduleVersion}.jar"
-            exec {
-                workingDir moduleClassesDir
-                commandLine (["$dex"] + moduleClasses + ['--classpath', "$rootDir/engine/build/classes",
-                                                         '--lib', "$path/platforms/android-$compileSdk/android.jar",
-                                                         '--min-api', "$minSdk",
-                                                         '--output', "$jarOutputDir"])
-            }
-            FileSystem jarFileSystem
-            try {
-                jarFileSystem = FileSystems.newFileSystem(URI.create("jar:" + new File(jarOutputDir).toURI()), new HashMap<String, Object>())
-                def moduleManifestContents =
-                        "{\n" +
-                        "    \"id\" : \"MODULE_ID\",\n" +
-                        "    \"version\" : \"MODULE_VERSION\",\n" +
-                        "    \"displayName\" : \"MODULE_NAME Code\",\n" +
-                        "    \"description\" : \"Code for MODULE_NAME\",\n" +
-                        "    \"dependencies\" :  [\n" +
-                        "        {\n" +
-                        "            \"id\" : \"MODULE_NAME\"\n" +
-                        "        }\n" +
-                        "    ]\n" +
-                        "}"
-                moduleManifestContents = moduleManifestContents
-                        .replace("MODULE_ID", module.name + "-code")
-                        .replace("MODULE_NAME", module.name)
-                        .replace("MODULE_VERSION", moduleVersion)
-                Files.write(jarFileSystem.getPath("module.json"), [moduleManifestContents], StandardCharsets.UTF_8)
-                Files.createDirectories(jarFileSystem.getPath("build/classes"))
-                moduleClassesFiles.each {
-                    Files.copy(it.toPath(), jarFileSystem.getPath("/build/classes/${it.name}"))
-                }
-            } catch (Exception e) {
-                e.printStackTrace()
-            } finally {
-                if (jarFileSystem != null) {
-                    jarFileSystem.close()
-                }
+        } catch (Exception e) {
+            e.printStackTrace()
+        } finally {
+            if (jarFileSystem != null) {
+                jarFileSystem.close()
             }
         }
     }
 }
 
-preBuild.dependsOn(reflectModules)
+preBuild.dependsOn(exportModules)
 
 def androidSdkPath() {
     def path

--- a/build.gradle
+++ b/build.gradle
@@ -80,11 +80,13 @@ dependencies {
     natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi-v7a"
     natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-arm64-v8a"
     natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-x86"
+    natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-x86_64"
     implementation "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-armeabi"
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-armeabi-v7a"
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-arm64-v8a"
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-x86"
+    natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-x86_64"
 
     // Android-compatible logging
     implementation group: 'org.slf4j', name: 'slf4j-android', version: '1.7.25'
@@ -181,6 +183,7 @@ task copyAndroidNatives() {
         if(jar.name.endsWith("natives-armeabi-v7a.jar")) outputDir = file("libs/armeabi-v7a")
         if(jar.name.endsWith("natives-armeabi.jar")) outputDir = file("libs/armeabi")
         if(jar.name.endsWith("natives-x86.jar")) outputDir = file("libs/x86")
+        if(jar.name.endsWith("natives-x86_64.jar")) outputDir = file("libs/x86_64")
         if(outputDir != null) {
             copy {
                 from zipTree(jar)


### PR DESCRIPTION
### Description
This pull request adds the arm64 library needed to run the game natively on `arm64-v8` versions of Android. It also makes logging via slf4j work and merges the code and assets back into a single jar (which were only ever split on Android versions). I believe that they were split originally due to performance problems with loading archives but this has not been as much of a problem since https://github.com/MovingBlocks/gestalt/pull/76 was merged.
### Notes
- This should fix #15 and assist with MovingBlocks/DestinationSol#513.
- This should also reduce the apk file size slightly, as external module assets are now contained within a compressed jar.