### PR TITLE
fix: detect later Android build-tools versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,12 +262,17 @@ def dexModules() {
     def buildToolsVersions = new File(path, "build-tools").listFiles(new FileFilter() {
         @Override
         boolean accept(File file) {
-            return file.isDirectory() && file.name.startsWith("$compileSdk.")
+            String[] versionParts = file.name.split('\\.');
+            if (versionParts.length < 3) {
+                // This is not an SDK build-tools directory
+                return false;
+            }
+            return file.isDirectory() && Integer.parseInt(versionParts[0]) >= compileSdk
         }
     })
 
     if (buildToolsVersions.length == 0) {
-        throw new TaskExecutionException(reflectModules, new FileNotFoundException("The Android SDK build tools version $compileSdk could not be found."))
+        throw new TaskExecutionException(exportModules, new FileNotFoundException("An Android SDK build tools version >= $compileSdk could not be found."))
     }
     def dex = "${buildToolsVersions[0]}/$dexCommand"
     for (module in rootProject.destinationSolModules()) {


### PR DESCRIPTION
This is just a small bugfix that allows later versions of the Android SDK build tools to be used. The Android Gradle Plugin version included by the build files requires a minimum of `build-tools;29.0.2` installed but the dexing code required `build-tools;28.0.x` to be installed as well. This changes the search logic in the module dexing code to use any version above the currently-set `compileSdkVersion`, allowing it to be used with `build-tools;29.0.2` only installed as well.