### PR TITLE
fix: fix engine module symlinks being zeroed-out when repeating clean build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,6 +254,10 @@ task exportModules() {
         deleteDir(assetsModulesDir)
         assetsModulesDir.mkdir()
 
+        // Delete the engine module symlink, since you cannot create a new symlink when one already exists.
+        def engineModuleDir = new File("$projectDir/assets", "engine")
+        deleteDir(engineModuleDir)
+
         boolean canCreateSymlinks
 
         try {


### PR DESCRIPTION
## Description
This fixes an inexplicable bug where every file in the engine build directory is zeroed-out and replaced with an empty file when doing several clean builds in succession. I missed this in my testing of #25 because it only happens on Linux/MacOS, whereas most of my local testing is on Windows. Windows doesn't support non-adminstrator symlinks until Java 13, so the file-copy fallback was always being invoked. It also only occurs when running the entire Jenkins pipeline in a single run, which I didn't do often due to the large quantities of time that it takes.
## Testing
Make sure that `./gradlew clean && ./gradlew :android:assembleDebug && cd android && fastlane buildRelease` produces a valid release APK. You can usually tell by the size of the APK, which is ~70-100MB for a valid APK but only ~10-30MB for an invalid one.