### PR TITLE
build: fix building with engine v2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,11 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        if (version == '2.0.0') {
+            classpath 'com.android.tools.build:gradle:3.2.1'
+        } else {
+            classpath 'com.android.tools.build:gradle:4.1.3'
+        }
     }
 }
 
@@ -71,7 +75,11 @@ dependencies {
     }
     // Android-compatible JOML variant
     implementation "org.joml:joml-jdk3:1.9.25"
-    implementation(group: 'org.terasology.gestalt', name: 'gestalt-android', version: '7.2.0-SNAPSHOT')
+    implementation(group: 'org.terasology.gestalt', name: 'gestalt-android', version: '7.2.0-SNAPSHOT') {
+        // Only include gestalt-android.
+        // This is safe because gestalt-android has not changed apart from to add the android assets file sources.
+        exclude group: "org.terasology.gestalt"
+    }
     // TODO: Needed for gestalt because of an internal dependency but since that dependency is never
     //       exposed in a public API, I have no idea why it's needed for compilation.
     implementation "com.github.zafarkhaja:java-semver:0.10.0"
@@ -287,6 +295,14 @@ task exportModules() {
                 include "assets/**"
                 include "module.json"
                 include "reflections.cache"
+            }
+
+            if (version == '2.0.0') {
+                copy {
+                    from "$rootDir/engine/build/classes/java/main"
+                    into "$projectDir/assets/engine"
+                    include "reflections.cache"
+                }
             }
 
             copy {

--- a/build.gradle
+++ b/build.gradle
@@ -286,7 +286,10 @@ task exportModules() {
 
                 file("$projectDir/assets/modules/${module.name}/build/classes").mkdirs()
                 Files.createSymbolicLink(Paths.get("$projectDir/assets/modules/${module.name}/build/classes/reflections.cache"), Paths.get("$rootDir/modules/${module.name}/build/classes/reflections.cache"))
-                Files.createSymbolicLink(Paths.get("$projectDir/assets/modules/${module.name}/build/dexes"), Paths.get("$rootDir/modules/${module.name}/build/dexes"))
+                def moduleDexesDir = "$rootDir/modules/${module.name}/build/dexes";
+                if (file(moduleDexesDir).exists()) {
+                    Files.createSymbolicLink(Paths.get("$projectDir/assets/modules/${module.name}/build/dexes"), Paths.get(moduleDexesDir))
+                }
             }
         } else {
             copy {

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,12 @@ dependencies {
         // This is safe because gestalt-android has not changed apart from to add the android assets file sources.
         exclude group: "org.terasology.gestalt"
     }
+
+    if (version == '2.0.0') {
+        // Gestalt does not use JavaAssist to compile
+        compileOnly 'org.javassist:javassist:3.20.0-GA'
+    }
+
     // TODO: Needed for gestalt because of an internal dependency but since that dependency is never
     //       exposed in a public API, I have no idea why it's needed for compilation.
     implementation "com.github.zafarkhaja:java-semver:0.10.0"
@@ -268,6 +274,14 @@ task exportModules() {
 
         boolean canCreateSymlinks
 
+        if (version == '2.0.0') {
+            copy {
+                from "$rootDir/engine/build/classes/java/main"
+                into "$rootDir/engine/build/resources/main/org/destinationsol"
+                include "reflections.cache"
+            }
+        }
+
         try {
             Files.createSymbolicLink(Paths.get("$projectDir/assets/engine"), Paths.get("$rootDir/engine/build/resources/main/org/destinationsol"))
             canCreateSymlinks = true
@@ -298,14 +312,6 @@ task exportModules() {
                 include "assets/**"
                 include "module.json"
                 include "reflections.cache"
-            }
-
-            if (version == '2.0.0') {
-                copy {
-                    from "$rootDir/engine/build/classes/java/main"
-                    into "$projectDir/assets/engine"
-                    include "reflections.cache"
-                }
             }
 
             copy {


### PR DESCRIPTION
Since it only required very minor changes to the build file, I've made it possible to use the android facade with the [`v2.0.0`](https://github.com/MovingBlocks/DestinationSol/tree/v2.0.0) source. This allows for a considerably smaller and more compatible android `2.0.0` re-release, if desired.

Ideally, if merged, this should go into a separate archival branch (named `release/v2.0.0` or similar) but it is not essential. I've guarded the differing code paths so that this will still work with the latest `develop` code. I will not be testing for `2.0.0` compatibility beyond this point though.